### PR TITLE
docs(translate): deployment/index/linux-perf 翻译

### DIFF
--- a/documentation/server/guides/deployment.md
+++ b/documentation/server/guides/deployment.md
@@ -1,27 +1,27 @@
 ---
 redirect_from: "server/guides/deployment"
 layout: page
-title: Deploying to Servers or Public Cloud
+title: 部署到服务器或公共云
 ---
 
-The following guides can help with the deployment to public cloud providers:
-* [AWS Lambda using the Serverless Application Model (SAM)](/documentation/server/guides/deploying/aws-sam-lambda.html)
-* [AWS Fargate with Vapor and MongoDB Atlas](/documentation/server/guides/deploying/aws-copilot-fargate-vapor-mongo.html)
+以下指南可以帮助您部署到公共云提供商：
+* [使用无服务器应用程序模型 (SAM) 部署到 AWS Lambda](/documentation/server/guides/deploying/aws-sam-lambda.html)
+* [使用 Vapor 和 MongoDB Atlas 部署到 AWS Fargate](/documentation/server/guides/deploying/aws-copilot-fargate-vapor-mongo.html)
 * [AWS EC2](/documentation/server/guides/deploying/aws.html)
 * [DigitalOcean](/documentation/server/guides/deploying/digital-ocean.html)
 * [Heroku](/documentation/server/guides/deploying/heroku.html)
-* [Kubernetes & Docker](/documentation/server/guides/packaging.html#docker)
+* [Kubernetes 和 Docker](/documentation/server/guides/packaging.html#docker)
 * [GCP](/documentation/server/guides/deploying/gcp.html)
-* _Have a guides for other popular public clouds like Azure? Add it here!_
+* _有其他流行公共云的指南吗？请在这里添加！_
 
-If you are deploying to your own servers (e.g. bare metal, VMs or Docker) there are several strategies for packaging Swift applications for deployment, see the [Packaging Guide](/server/guides/packaging.html) for more information.
+如果您正在部署到自己的服务器（例如裸机、虚拟机或 Docker），有几种策略可以将 Swift 应用程序打包以进行部署，请参阅 [打包指南](/server/guides/packaging.html) 以获取更多信息。
 
-## Deploying a Debuggable Configuration (Production on Linux)
+## 部署可调试配置（Linux 上的生产环境）
 
-- If you have `--privileged`/`--security-opt seccomp=unconfined` containers or are running in VMs or even bare metal, you can run your binary with
+- 如果您有 `--privileged`/`--security-opt seccomp=unconfined` 容器，或者在虚拟机甚至裸机上运行，您可以使用以下命令运行您的二进制文件
 
         lldb --batch -o "break set -n main --auto-continue 1 -C \"process handle SIGPIPE -s 0\"" -o run -k "image list" -k "register read" -k "bt all" -k "exit 134" ./my-program
 
-    instead of `./my-program` to get something akin to a 'crash report' on crash.
+    而不是 `./my-program` 以在崩溃时获得类似于“崩溃报告”的内容。
 
-- If you don't have `--privileged` (or `--security-opt seccomp=unconfined`) containers (meaning you won't be able to use `lldb`) or you don't want to use lldb, consider using a library like [`swift-backtrace`](https://github.com/swift-server/swift-backtrace) to get stack traces on crash.
+- 如果您没有 `--privileged`（或 `--security-opt seccomp=unconfined`）容器（意味着您将无法使用 `lldb`）或者您不想使用 lldb，请考虑使用类似 [`swift-backtrace`](https://github.com/swift-server/swift-backtrace) 的库在崩溃时获取堆栈跟踪。

--- a/documentation/server/guides/index.md
+++ b/documentation/server/guides/index.md
@@ -1,26 +1,26 @@
 ---
 layout: page
-title: Swift on Server Guides
+title: 服务器上的 Swift 指南
 ---
 
-The Swift Server Workgroup and Swift on Server community have developed a number of guides for using Swift on the server. They are designed to help teams and individuals running Swift Server applications on Linux and to provide orientation for those who want to start with such development.
+Swift 服务器工作组和服务器上的 Swift 社区已经开发了许多在服务器上使用 Swift 的指南。它们旨在帮助团队和个人在 Linux 上运行 Swift 服务器应用程序，并为那些想要开始这种开发的人提供指导。
 
-They focus on how to compile, test, deploy and debug such application and provides tips in those areas.
+这些指南侧重于如何编译、测试、部署和调试此类应用程序，并在这些领域提供提示。
 
-- [Setup and code editing](/documentation/server/guides/setup-and-ide-alternatives.html)
-- [Building](/documentation/server/guides/building.html)
-- [Testing](/documentation/server/guides/testing.html)
-- [Debugging Memory leaks](/documentation/server/guides/memory-leaks-and-usage.html)
-- [Performance troubleshooting and analysis](/documentation/server/guides/performance.html)
-- [Optimizing allocations](/documentation/server/guides/allocations.html)
-- [Debugging multithreading issues and memory checks](/documentation/server/guides/llvm-sanitizers.html)
-- [Deployment](/documentation/server/guides/deployment.html)
-- [Packaging](/documentation/server/guides/packaging.html)
-- [Passkeys](/documentation/server/guides/passkeys.html)
+- [设置和代码编辑](/documentation/server/guides/setup-and-ide-alternatives.html)
+- [构建](/documentation/server/guides/building.html)
+- [测试](/documentation/server/guides/testing.html)
+- [调试内存泄漏](/documentation/server/guides/memory-leaks-and-usage.html)
+- [性能故障排除和分析](/documentation/server/guides/performance.html)
+- [优化分配](/documentation/server/guides/allocations.html)
+- [调试多线程问题和内存检查](/documentation/server/guides/llvm-sanitizers.html)
+- [部署](/documentation/server/guides/deployment.html)
+- [打包](/documentation/server/guides/packaging.html)
+- [通行密钥](/documentation/server/guides/passkeys.html)
 
-Additionally, there are specific guides for library developers:
+此外，还有针对库开发人员的特定指南：
 
-* [Log Levels](/documentation/server/guides/libraries/log-levels.html)
-* [Adopting Swift Concurrency](/documentation/server/guides/libraries/concurrency-adoption-guidelines.html)
+* [日志级别](/documentation/server/guides/libraries/log-levels.html)
+* [采用 Swift 并发](/documentation/server/guides/libraries/concurrency-adoption-guidelines.html)
 
-_These guides are community effort, and all are invited to share their tips and know-how by submitting pull requests to the [Swift.org site](https://github.com/swiftlang/swift-org-website)_.
+_这些指南是社区的努力成果，欢迎所有人通过向 [Swift.org 网站](https://github.com/swiftlang/swift-org-website) 提交拉取请求来分享他们的提示和知识_。

--- a/documentation/server/guides/linux-perf.md
+++ b/documentation/server/guides/linux-perf.md
@@ -4,29 +4,29 @@ layout: page
 title: Linux perf
 ---
 
-## `perf`, what's that?
+## `perf` 是什么？
 
-The Linux [`perf` tool](https://perf.wiki.kernel.org/index.php/Main_Page) is an incredibly powerful tool, that can amongst other things be used for:
+Linux [`perf` 工具](https://perf.wiki.kernel.org/index.php/Main_Page) 是一个非常强大的工具，它可以用于：
 
-- Sampling CPU-bound processes (or the whole) system to analyse which part of your application is consuming the CPU time
-- Accessing CPU performance counters (PMU)
-- "user probes" (uprobes) which trigger for example when a certain function in your application runs
+- 采样 CPU 绑定的进程（或整个系统）以分析应用程序的哪个部分在消耗 CPU 时间
+- 访问 CPU 性能计数器 (PMU)
+- "用户探针" (uprobes)，例如在应用程序中的某个函数运行时触发
 
-In general, `perf` can count and/or record the call stacks of your threads when a certain event occurs. These events can be triggered by:
+一般来说，`perf` 可以在某个事件发生时计数和/或记录线程的调用栈。这些事件可以由以下情况触发：
 
-- Time (e.g. 1000 times per second), useful for time profiling. For an example use, see the [CPU performance debugging guide](/documentation/server/guides/performance.html).
-- System calls, useful to see where your system calls are happening.
-- Various system events, for example if you'd like to know when context switches occur.
-- CPU performance counters, useful if your performance issues can be traced down to micro-architectural details of your CPU (such as branch mispredictions). For an example, see [SwiftNIO's Advanced Performance Analysis guide](https://github.com/apple/swift-nio/blob/main/docs/advanced-performance-analysis.md).
-- and much more
+- 时间（例如每秒 1000 次），用于时间分析。有关示例用法，请参阅 [CPU 性能调试指南](/documentation/server/guides/performance.html)。
+- 系统调用，用于查看系统调用发生的位置。
+- 各种系统事件，例如如果您想知道上下文切换何时发生。
+- CPU 性能计数器，如果您的性能问题可以追溯到 CPU 的微架构细节（例如分支预测失败），这将非常有用。有关示例，请参阅 [SwiftNIO 的高级性能分析指南](https://github.com/apple/swift-nio/blob/main/docs/advanced-performance-analysis.md)。
+- 以及更多
 
-## Getting `perf` to work
+## 使 `perf` 工作
 
-Unfortunately, getting `perf` to work depends on your environment. Below, please find a selection of environments and how to get `perf` to work there.
+不幸的是，使 `perf` 工作取决于您的环境。请在下面找到一些环境以及如何在这些环境中使 `perf` 工作。
 
-### Installing `perf`
+### 安装 `perf`
 
-Technically, `perf` is part of the Linux kernel sources and you'd want a `perf` version that exactly matches your Linux kernel version. In many cases however a "close-enough" `perf` version will do too. If in doubt, use a `perf` version that's slightly older than your kernel over one that's newer.
+从技术上讲，`perf` 是 Linux 内核源代码的一部分，您需要一个与您的 Linux 内核版本完全匹配的 `perf` 版本。然而，在许多情况下，一个“足够接近”的 `perf` 版本也可以。如果有疑问，请使用比您的内核稍旧的 `perf` 版本，而不是更新的版本。
 
 - Ubuntu
 
@@ -34,7 +34,7 @@ Technically, `perf` is part of the Linux kernel sources and you'd want a `perf` 
     apt-get update && apt-get -y install linux-tools-generic
     ```
 
-  See below for more information because Ubuntu packages a different `perf` per kernel version.
+  请参阅下文了解更多信息，因为 Ubuntu 为每个内核版本打包了不同的 `perf`。
 - Debian
 
     ```
@@ -47,12 +47,12 @@ Technically, `perf` is part of the Linux kernel sources and you'd want a `perf` 
    yum install -y perf
    ```
 
-You can confirm that your `perf` installation works using  `perf stat -- sleep 0.1` (if you're already `root`) or `sudo perf stat -- sleep 0.1`.
+您可以使用 `perf stat -- sleep 0.1`（如果您已经是 `root`）或 `sudo perf stat -- sleep 0.1` 来确认您的 `perf` 安装是否正常工作。
 
 
-##### `perf` on Ubuntu when you can't match the kernel version
+##### `perf` 在 Ubuntu 上无法匹配内核版本时
 
-On Ubuntu (and other distributions that package `perf` per kernel version) you may see an error after installing `linux-tools-generic`. The error message will look similar to
+在 Ubuntu（以及其他为每个内核版本打包 `perf` 的发行版）上，您可能会在安装 `linux-tools-generic` 后看到错误。错误消息将类似于
 
 ```
 $ perf stat -- sleep 0.1
@@ -67,39 +67,39 @@ WARNING: perf not found for kernel 5.10.25
     linux-cloud-tools-linuxkit
 ```
 
-The best fix for this is to follow what `perf` says and to install one of the above packages. If you're in a Docker container, this may not be possible because you'd need to match the kernel version (which is especially difficult in Docker for Mac because it uses a VM). For example, the suggested `linux-tools-5.10.25-linuxkit` is not actually available.
+最好的解决方法是按照 `perf` 的提示安装上述软件包之一。如果您在 Docker 容器中，这可能是不可能的，因为您需要匹配内核版本（在 Docker for Mac 中尤其困难，因为它使用虚拟机）。例如，建议的 `linux-tools-5.10.25-linuxkit` 实际上不可用。
 
-As a workaround, you can try one of the following options
+作为一种解决方法，您可以尝试以下选项之一
 
-- If you're already `root` and prefer a shell `alias` (only valid in this shell)
+- 如果您已经是 `root` 并且更喜欢 shell `alias`（仅在此 shell 中有效）
 
     ```
     alias perf=$(find /usr/lib/linux-tools/*/perf | head -1)
     ```
 
-- If you're a user and would like to prefer to link `/usr/local/bin/perf`
+- 如果您是用户并且希望链接 `/usr/local/bin/perf`
 
     ```
     sudo ln -s "$(find /usr/lib/linux-tools/*/perf | head -1)" /usr/local/bin/perf
     ```
 
-After this, you should be able to use `perf stat -- sleep 0.1` (if you're already `root`) or `sudo perf stat -- sleep 0.1` successfully.
+之后，您应该能够成功使用 `perf stat -- sleep 0.1`（如果您已经是 `root`）或 `sudo perf stat -- sleep 0.1`。
 
-### Bare metal
+### 裸机
 
-For a bare metal Linux machine, all you need to do is to install `perf` which should then work in full fidelity.
+对于裸机 Linux 机器，您只需安装 `perf`，它应该可以完全正常工作。
 
-### In Docker (running on bare-metal Linux)
+### 在 Docker 中（运行在裸机 Linux 上）
 
-You will need to launch your container with `docker run --privileged` (don't run this in production) and then you should have full access to perf (including the PMU).
+您需要使用 `docker run --privileged` 启动容器（不要在生产环境中运行此命令），然后您应该可以完全访问 perf（包括 PMU）。
 
-To validate that `perf` works correctly, run for example `perf stat -- sleep 0.1`. Whether you'll see the `<not supported>` next to some information will depend on if you have access to the CPU's performance counters (the PMU). In Docker on bare metal, this should work, ie. no `<not supported>`s should show up.
+要验证 `perf` 是否正常工作，请运行例如 `perf stat -- sleep 0.1`。是否会看到某些信息旁边的 `<not supported>` 取决于您是否可以访问 CPU 的性能计数器（PMU）。在裸机上的 Docker 中，这应该可以工作，即不应显示 `<not supported>`。
 
 ### Docker for Mac
 
-Docker for Mac is like Docker on bare metal but with some extra complexity because we're actually running the Docker containers hosted in a Linux VM. So matching the kernel version will be difficult.
+Docker for Mac 类似于裸机上的 Docker，但由于我们实际上在 Linux 虚拟机中托管 Docker 容器，因此增加了一些复杂性。因此，匹配内核版本将很困难。
 
-If you follow the above installation instructions, you should nevertheless get `perf` to work but you won't have access to the CPU's performance counters (the PMU) so you'll see a few events show up as `<not supported>`.
+如果您按照上述安装说明进行操作，您仍然可以使 `perf` 工作，但您将无法访问 CPU 的性能计数器（PMU），因此您会看到一些事件显示为 `<not supported>`。
 
 ```
 $ perf stat -- sleep 0.1
@@ -121,14 +121,14 @@ $ perf stat -- sleep 0.1
        0.001069000 seconds sys
 ```
 
-### In a VM
+### 在虚拟机（VM）中
 
-In a virtual machine, you would install `perf` just like on bare metal. And either `perf` will work just fine with all its features or it will look similarly to what you get on Docker for Mac.
+在虚拟机中，您将像在裸机上一样安装 `perf`。并且 `perf` 要么可以正常工作并具有其所有功能，要么看起来类似于您在 Docker for Mac 上获得的结果。
 
-What you need your hypervisor to support (& allow) is "PMU passthrough" or "PMU virtualisation". VMware Fusion does support PMU virtualisation which they call vPMC (VM settings -> Processors & Memory -> Advanced -> Allow code profiling applications in this VM). If you're on a Mac this setting is unfortunately only supported up to including macOS Catalina (and [not on Big Sur](https://kb.vmware.com/s/article/81623)).
+您需要您的虚拟机管理程序支持（并允许）“PMU 直通”或“PMU 虚拟化”。VMware Fusion 支持 PMU 虚拟化，他们称之为 vPMC（虚拟机设置 -> 处理器和内存 -> 高级 -> 允许在此虚拟机就中进行代码分析应用程序）。如果您使用的是 Mac，此设置仅支持到 macOS Catalina（并且[不支持 Big Sur](https://kb.vmware.com/s/article/81623)）。
 
-If you use `libvirt` to manage your hypervisor and VMs, you can use `sudo virsh edit your-domain` and replace the `<cpu .../>` XML tag with
+如果您使用 `libvirt` 来管理您的虚拟机管理程序和虚拟机，您可以使用 `sudo virsh edit your-domain` 并将 `<cpu .../>` XML 标签替换为
 
     <cpu mode='host-passthrough' check='none'/>
 
-to allow the PMU to be passed through to the guest. For other hypervisors, an internet search will usually reveal how to enable PMU passthrough.
+以允许 PMU 直通到访客。对于其他虚拟机管理程序，互联网搜索通常会揭示如何启用 PMU 直通。


### PR DESCRIPTION
### 翻译内容
- 文件路径：/documentation/server/guides/(deployment|index|linux-perf)
- 相关 Issue：
  - close #30 
  - close #31 
  - close #32
### 翻译检查清单
- [x] 已检查专业术语一致性
- [x] 已进行本地预览测试
- [x] 保持了原文格式
- [x] 确保文件编码为 UTF-8
- [x] 添加了必要的注释

### 其他说明
/